### PR TITLE
feat: replace in-memory storage with persistent SQLite database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ __pycache__
 
 # Env files
 .env
+slalom_capabilities.db

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
 uvicorn
+sqlalchemy
 pytest
 httpx

--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,18 @@ A FastAPI application that enables Slalom consultants to register their
 capabilities and manage consulting expertise across the organization.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
 import os
 from pathlib import Path
+
+from src.database import engine, get_db, Base
+from src import models
+
+# Create all tables on startup
+Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Slalom Capabilities Management API",
               description="API for managing consulting capabilities and consultant expertise")
@@ -19,90 +26,129 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory capabilities database
-capabilities = {
-    "Cloud Architecture": {
+# Seed data used to populate an empty database on first run
+SEED_CAPABILITIES = [
+    {
+        "name": "Cloud Architecture",
         "description": "Design and implement scalable cloud solutions using AWS, Azure, and GCP",
         "practice_area": "Technology",
         "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
         "certifications": ["AWS Solutions Architect", "Azure Architect Expert"],
         "industry_verticals": ["Healthcare", "Financial Services", "Retail"],
-        "capacity": 40,  # hours per week available across team
-        "consultants": ["alice.smith@slalom.com", "bob.johnson@slalom.com"]
+        "capacity": 40,
+        "consultants": ["alice.smith@slalom.com", "bob.johnson@slalom.com"],
     },
-    "Data Analytics": {
+    {
+        "name": "Data Analytics",
         "description": "Advanced data analysis, visualization, and machine learning solutions",
-        "practice_area": "Technology", 
+        "practice_area": "Technology",
         "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
         "certifications": ["Tableau Desktop Specialist", "Power BI Expert", "Google Analytics"],
         "industry_verticals": ["Retail", "Healthcare", "Manufacturing"],
         "capacity": 35,
-        "consultants": ["emma.davis@slalom.com", "sophia.wilson@slalom.com"]
+        "consultants": ["emma.davis@slalom.com", "sophia.wilson@slalom.com"],
     },
-    "DevOps Engineering": {
+    {
+        "name": "DevOps Engineering",
         "description": "CI/CD pipeline design, infrastructure automation, and containerization",
         "practice_area": "Technology",
-        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"], 
+        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
         "certifications": ["Docker Certified Associate", "Kubernetes Admin", "Jenkins Certified"],
         "industry_verticals": ["Technology", "Financial Services"],
         "capacity": 30,
-        "consultants": ["john.brown@slalom.com", "olivia.taylor@slalom.com"]
+        "consultants": ["john.brown@slalom.com", "olivia.taylor@slalom.com"],
     },
-    "Digital Strategy": {
+    {
+        "name": "Digital Strategy",
         "description": "Digital transformation planning and strategic technology roadmaps",
         "practice_area": "Strategy",
         "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
         "certifications": ["Digital Transformation Certificate", "Agile Certified Practitioner"],
         "industry_verticals": ["Healthcare", "Financial Services", "Government"],
         "capacity": 25,
-        "consultants": ["liam.anderson@slalom.com", "noah.martinez@slalom.com"]
+        "consultants": ["liam.anderson@slalom.com", "noah.martinez@slalom.com"],
     },
-    "Change Management": {
+    {
+        "name": "Change Management",
         "description": "Organizational change leadership and adoption strategies",
         "practice_area": "Operations",
         "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
         "certifications": ["Prosci Certified", "Lean Six Sigma Black Belt"],
         "industry_verticals": ["Healthcare", "Manufacturing", "Government"],
         "capacity": 20,
-        "consultants": ["ava.garcia@slalom.com", "mia.rodriguez@slalom.com"]
+        "consultants": ["ava.garcia@slalom.com", "mia.rodriguez@slalom.com"],
     },
-    "UX/UI Design": {
+    {
+        "name": "UX/UI Design",
         "description": "User experience design and digital product innovation",
         "practice_area": "Technology",
         "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
         "certifications": ["Adobe Certified Expert", "Google UX Design Certificate"],
         "industry_verticals": ["Retail", "Healthcare", "Technology"],
         "capacity": 30,
-        "consultants": ["amelia.lee@slalom.com", "harper.white@slalom.com"]
+        "consultants": ["amelia.lee@slalom.com", "harper.white@slalom.com"],
     },
-    "Cybersecurity": {
+    {
+        "name": "Cybersecurity",
         "description": "Information security strategy, risk assessment, and compliance",
         "practice_area": "Technology",
         "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
         "certifications": ["CISSP", "CISM", "CompTIA Security+"],
         "industry_verticals": ["Financial Services", "Healthcare", "Government"],
         "capacity": 25,
-        "consultants": ["ella.clark@slalom.com", "scarlett.lewis@slalom.com"]
+        "consultants": ["ella.clark@slalom.com", "scarlett.lewis@slalom.com"],
     },
-    "Business Intelligence": {
+    {
+        "name": "Business Intelligence",
         "description": "Enterprise reporting, data warehousing, and business analytics",
         "practice_area": "Technology",
         "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
         "certifications": ["Microsoft BI Certification", "Qlik Sense Certified"],
         "industry_verticals": ["Retail", "Manufacturing", "Financial Services"],
         "capacity": 35,
-        "consultants": ["james.walker@slalom.com", "benjamin.hall@slalom.com"]
+        "consultants": ["james.walker@slalom.com", "benjamin.hall@slalom.com"],
     },
-    "Agile Coaching": {
+    {
+        "name": "Agile Coaching",
         "description": "Agile transformation and team coaching for scaled delivery",
         "practice_area": "Operations",
         "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
         "certifications": ["Certified Scrum Master", "SAFe Agilist", "ICAgile Certified"],
         "industry_verticals": ["Technology", "Financial Services", "Healthcare"],
         "capacity": 20,
-        "consultants": ["charlotte.young@slalom.com", "henry.king@slalom.com"]
-    }
-}
+        "consultants": ["charlotte.young@slalom.com", "henry.king@slalom.com"],
+    },
+]
+
+
+def seed_database(db: Session) -> None:
+    """Populate the database with initial capabilities if it is empty."""
+    if db.query(models.Capability).count() > 0:
+        return
+    for entry in SEED_CAPABILITIES:
+        capability = models.Capability(
+            name=entry["name"],
+            description=entry["description"],
+            practice_area=entry["practice_area"],
+            skill_levels=entry["skill_levels"],
+            certifications=entry["certifications"],
+            industry_verticals=entry["industry_verticals"],
+            capacity=entry["capacity"],
+        )
+        db.add(capability)
+        for email in entry["consultants"]:
+            db.add(models.ConsultantCapability(capability_name=entry["name"], email=email))
+    db.commit()
+
+
+@app.on_event("startup")
+def startup_event():
+    from src.database import SessionLocal
+    db = SessionLocal()
+    try:
+        seed_database(db)
+    finally:
+        db.close()
 
 
 @app.get("/")
@@ -111,49 +157,68 @@ def root():
 
 
 @app.get("/capabilities")
-def get_capabilities():
-    return capabilities
+def get_capabilities(db: Session = Depends(get_db)):
+    capabilities = db.query(models.Capability).all()
+    result = {}
+    for cap in capabilities:
+        consultants = (
+            db.query(models.ConsultantCapability)
+            .filter(models.ConsultantCapability.capability_name == cap.name)
+            .all()
+        )
+        result[cap.name] = {
+            "description": cap.description,
+            "practice_area": cap.practice_area,
+            "skill_levels": cap.skill_levels,
+            "certifications": cap.certifications,
+            "industry_verticals": cap.industry_verticals,
+            "capacity": cap.capacity,
+            "consultants": [c.email for c in consultants],
+        }
+    return result
 
 
 @app.post("/capabilities/{capability_name}/register")
-def register_for_capability(capability_name: str, email: str):
+def register_for_capability(capability_name: str, email: str, db: Session = Depends(get_db)):
     """Register a consultant for a capability"""
-    # Validate capability exists
-    if capability_name not in capabilities:
+    capability = db.query(models.Capability).filter(models.Capability.name == capability_name).first()
+    if not capability:
         raise HTTPException(status_code=404, detail="Capability not found")
 
-    # Get the specific capability
-    capability = capabilities[capability_name]
-
-    # Validate consultant is not already registered
-    if email in capability["consultants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Consultant is already registered for this capability"
+    existing = (
+        db.query(models.ConsultantCapability)
+        .filter(
+            models.ConsultantCapability.capability_name == capability_name,
+            models.ConsultantCapability.email == email,
         )
+        .first()
+    )
+    if existing:
+        raise HTTPException(status_code=400, detail="Consultant is already registered for this capability")
 
-    # Add consultant
-    capability["consultants"].append(email)
+    db.add(models.ConsultantCapability(capability_name=capability_name, email=email))
+    db.commit()
     return {"message": f"Registered {email} for {capability_name}"}
 
 
 @app.delete("/capabilities/{capability_name}/unregister")
-def unregister_from_capability(capability_name: str, email: str):
+def unregister_from_capability(capability_name: str, email: str, db: Session = Depends(get_db)):
     """Unregister a consultant from a capability"""
-    # Validate capability exists
-    if capability_name not in capabilities:
+    capability = db.query(models.Capability).filter(models.Capability.name == capability_name).first()
+    if not capability:
         raise HTTPException(status_code=404, detail="Capability not found")
 
-    # Get the specific capability
-    capability = capabilities[capability_name]
-
-    # Validate consultant is registered
-    if email not in capability["consultants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Consultant is not registered for this capability"
+    record = (
+        db.query(models.ConsultantCapability)
+        .filter(
+            models.ConsultantCapability.capability_name == capability_name,
+            models.ConsultantCapability.email == email,
         )
+        .first()
+    )
+    if not record:
+        raise HTTPException(status_code=400, detail="Consultant is not registered for this capability")
 
-    # Remove consultant
-    capability["consultants"].remove(email)
+    db.delete(record)
+    db.commit()
     return {"message": f"Unregistered {email} from {capability_name}"}

--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,27 @@
+"""
+Database configuration and session management.
+Uses SQLite via SQLAlchemy for local persistence.
+"""
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+import os
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./slalom_capabilities.db")
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,30 @@
+"""
+SQLAlchemy ORM models for the Slalom Capabilities Management System.
+"""
+
+from sqlalchemy import Column, String, Integer, JSON, ForeignKey, UniqueConstraint
+from src.database import Base
+
+
+class Capability(Base):
+    __tablename__ = "capabilities"
+
+    name = Column(String, primary_key=True, index=True)
+    description = Column(String, nullable=False)
+    practice_area = Column(String, nullable=False)
+    skill_levels = Column(JSON, nullable=False, default=list)
+    certifications = Column(JSON, nullable=False, default=list)
+    industry_verticals = Column(JSON, nullable=False, default=list)
+    capacity = Column(Integer, nullable=False, default=0)
+
+
+class ConsultantCapability(Base):
+    __tablename__ = "consultant_capabilities"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    capability_name = Column(String, ForeignKey("capabilities.name", ondelete="CASCADE"), nullable=False)
+    email = Column(String, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("capability_name", "email", name="uq_consultant_capability"),
+    )


### PR DESCRIPTION
## Summary

Replaces the in-memory Python dict with a persistent relational database backed by SQLite via SQLAlchemy.

Closes #8

## Changes

- **`src/database.py`** — New file. SQLAlchemy engine setup, `SessionLocal`, and `get_db` FastAPI dependency. The database URL defaults to `sqlite:///./slalom_capabilities.db` and can be overridden via the `DATABASE_URL` environment variable.
- **`src/models.py`** — New file. Two ORM models:
  - `Capability` — stores name, description, practice area, skill levels, certifications, industry verticals, and capacity.
  - `ConsultantCapability` — links a consultant email to a capability with a unique constraint to prevent duplicate registrations.
- **`src/app.py`** — Refactored all three endpoints (`GET /capabilities`, `POST /register`, `DELETE /unregister`) to use DB sessions via `Depends(get_db)`. Added `seed_database()` which populates the DB with the original capability data on first startup.
- **`requirements.txt`** — Added `sqlalchemy`.
- **`.gitignore`** — Added `slalom_capabilities.db`.

## Testing

App imports cleanly and seeding was verified: 9 capabilities and 18 consultant registrations written to SQLite on first run. Data now survives application restarts.